### PR TITLE
Simultaneous uploads

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,3 @@
 codecov==2.0.15
 pytest==5.0.1
+pytest-cov==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 click==7.0
+<<<<<<< HEAD
 git+https://github.com/CIMAC-CIDC/cidc-schemas@release
 git+https://github.com/CIMAC-CIDC/cidc-utils
+=======
+git+https://github.com/CIMAC-CIDC/cidc-schemas.git@e65c385345afa5d67cd22ba7334fef35ef8f48e5#egg=cidc-schemas
+git+https://github.com/CIMAC-CIDC/cidc-utils@2f2cf82007a3a67971293752e1dc168a7aad10e3#egg=cidc-utils
+>>>>>>> Remove pipenv dependency and simplify requirements
 python-dotenv==0.10.3
 python-jose==3.0.1
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
 click==7.0
-<<<<<<< HEAD
 git+https://github.com/CIMAC-CIDC/cidc-schemas@release
 git+https://github.com/CIMAC-CIDC/cidc-utils
-=======
-git+https://github.com/CIMAC-CIDC/cidc-schemas.git@e65c385345afa5d67cd22ba7334fef35ef8f48e5#egg=cidc-schemas
-git+https://github.com/CIMAC-CIDC/cidc-utils@2f2cf82007a3a67971293752e1dc168a7aad10e3#egg=cidc-utils
->>>>>>> Remove pipenv dependency and simplify requirements
 python-dotenv==0.10.3
 python-jose==3.0.1
 requests==2.22.0

--- a/tests/cli2/util.py
+++ b/tests/cli2/util.py
@@ -1,0 +1,29 @@
+from threading import Thread
+
+
+class ExceptionCatchingThread(Thread):
+    """
+    A thread that throws any exception it encounters while
+    running when its `join` method is called.
+    """
+
+    def __init__(self, target):
+        Thread.__init__(self)
+        self.target = target
+
+    def run(self):
+        self.exc = None
+        try:
+            self.target()
+        except:
+            import sys
+            self.exc = sys.exc_info()
+
+    def join(self):
+        Thread.join(self)
+        if self.exc:
+            msg = "Thread '%s' threw an exception: %s" % (
+                self.getName(), self.exc[1])
+            new_exc = self.exc[0](msg)
+            new_exc.with_traceback(self.exc[2])
+            raise new_exc


### PR DESCRIPTION
This PR updates `cli2` uploads to create a unique upload workspace for every run, which keep parallel upload runs filesystem operations sandboxed from each other. Also, adds a smoketest that runs two uploads in parallel.