### PR TITLE
non prod env usage warning

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -22,7 +22,7 @@ def login(portal_token):
     click.echo("You are now logged in.")
 
 #### $ cidc config ####
-@click.group('config')
+@click.group('config', hidden=True)
 def config_():
     """Manage CLI configuration."""
 
@@ -40,15 +40,12 @@ def get_env():
     """Get the current CLI environment."""
     click.echo(config.get_env())
 
-#### $ cidc manifests ####
-@click.group()
-def manifests():
-    """Manage manifest data."""
-
 #### $ cidc assays ####
 @click.group()
-def assays():
+@click.option('-i', '--ignore', default=None, hidden=True)
+def assays(ignore):
     """Manage assay data."""
+    config.check_env_warning(ignore)
 
 #### $ cidc assays list ####
 @click.command("list")
@@ -71,7 +68,6 @@ def upload_assay(assay, xlsx):
 
 # Wire up the interface
 cidc.add_command(login)
-cidc.add_command(manifests)
 cidc.add_command(assays)
 cidc.add_command(config_)
 

--- a/cli/config.py
+++ b/cli/config.py
@@ -1,4 +1,5 @@
 import os
+from time import sleep
 from pathlib import Path
 
 from . import cache
@@ -22,6 +23,51 @@ def get_env():
     """Get the current CLI environment"""
     return cache.get(_ENV_KEY) or 'prod'
 
+_WARNING = '\n'.join([
+ '##      ##    ###    ########  ##    ## #### ##    ##  ######   ',
+ '##  ##  ##   ## ##   ##     ## ###   ##  ##  ###   ## ##    ##  ',
+ '##  ##  ##  ##   ##  ##     ## ####  ##  ##  ####  ## ##        ',
+ '##  ##  ## ##     ## ########  ## ## ##  ##  ## ## ## ##   #### ',
+ '##  ##  ## ######### ##   ##   ##  ####  ##  ##  #### ##    ##  ',
+ '##  ##  ## ##     ## ##    ##  ##   ###  ##  ##   ### ##    ##  ',
+ ' ###  ###  ##     ## ##     ## ##    ## #### ##    ##  ######   ',
+ ''
+])
+_STRIKE = '*'*64
+
+def check_env_warning(ignore_env):
+    """Get the current CLI environment"""
+    if get_env() != 'prod':
+    	print(_STRIKE)
+    	print(_WARNING)
+    	print(_STRIKE)
+    	print(f'You are using DEVELOPMENT environment ({get_env()}).')
+    	if ignore_env != None and ignore_env == get_env():
+	    	print(_STRIKE)
+	    	return
+
+    	print('If you are not sure what that means, stop now.')
+    	print(_STRIKE)
+    	sleep(1)
+    	reply = str(input('Proceed anyways (y/n): ')).lower().strip()
+    	print(_STRIKE)
+    	if reply != 'y':
+	    	q = ('Do you want to set default environment')
+    		reply = str(input(q + ' (y/n): ')).lower().strip()
+    		if reply == 'y':
+    			set_env('prod')
+		    	print(_STRIKE)
+		    	print('Environment set to default, you can retry now.')
+    		exit(0)
+
+    if ignore_env != None and ignore_env != get_env():
+    	print(_STRIKE)
+    	print(_WARNING)
+    	print(_STRIKE)
+    	print(f'You are using PRODUCTION environment, not {ignore_env}')
+    	print(f'Remove `--ignore {ignore_env}` and retry.')
+    	print(_STRIKE)
+    	exit(0)
 
 # Environment-specific config
 _current_env = get_env()

--- a/cli/config.py
+++ b/cli/config.py
@@ -1,6 +1,7 @@
 import os
 from time import sleep
 from pathlib import Path
+import click
 
 from . import cache
 
@@ -38,36 +39,28 @@ _STRIKE = '*'*64
 def check_env_warning(ignore_env):
     """Get the current CLI environment"""
     if get_env() != 'prod':
-    	print(_STRIKE)
-    	print(_WARNING)
-    	print(_STRIKE)
-    	print(f'You are using DEVELOPMENT environment ({get_env()}).')
-    	if ignore_env != None and ignore_env == get_env():
-	    	print(_STRIKE)
-	    	return
+        print(_STRIKE + '\n' + _WARNING + _STRIKE)
+        print(f'You are using DEVELOPMENT environment ({get_env()})')
+        if ignore_env != None and ignore_env == get_env():
+            return
 
-    	print('If you are not sure what that means, stop now.')
-    	print(_STRIKE)
-    	sleep(1)
-    	reply = str(input('Proceed anyways (y/n): ')).lower().strip()
-    	print(_STRIKE)
-    	if reply != 'y':
-	    	q = ('Do you want to set default environment')
-    		reply = str(input(q + ' (y/n): ')).lower().strip()
-    		if reply == 'y':
-    			set_env('prod')
-		    	print(_STRIKE)
-		    	print('Environment set to default, you can retry now.')
-    		exit(0)
+        print('If you are not sure what that means, stop now.\n' + _STRIKE)
+        
+        if not click.confirm('Proceed anyways?'):
+            if click.confirm('Do you want to reset the CLI to its default configuration?'):
+                set_env('prod')
+                print(_STRIKE)
+                print('Environment set to default, you can retry now.')
+            exit(0)
+        
+        print(_STRIKE)
 
     if ignore_env != None and ignore_env != get_env():
-    	print(_STRIKE)
-    	print(_WARNING)
-    	print(_STRIKE)
-    	print(f'You are using PRODUCTION environment, not {ignore_env}')
-    	print(f'Remove `--ignore {ignore_env}` and retry.')
-    	print(_STRIKE)
-    	exit(0)
+        print(_STRIKE + '\n' + _WARNING + _STRIKE)
+        print(f'You are using PRODUCTION environment, not {ignore_env}')
+        print(f'Remove `--ignore {ignore_env}` and retry.')
+        print(_STRIKE)
+        exit(0)
 
 # Environment-specific config
 _current_env = get_env()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="cidc_cli",
-    version="0.4.3",
+    version="0.4.4",
     packages=find_packages(exclude=("tests")),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
I made `config` command hidden - so only we can use it, 
then I removed `manifests` completely - they were not used.

I added this WARNING for when env is set for not `prod`. 
  