### PR TITLE
Poll API for cloud function completion on assay upload

### DIFF
--- a/cli/api.py
+++ b/cli/api.py
@@ -130,6 +130,7 @@ def assay_upload_failed(job_id: int, etag: str):
 
 class MergeStatus(NamedTuple):
     status: Optional[str]
+    status_details: Optional[str]
     retry_in: Optional[int]
 
 
@@ -144,10 +145,11 @@ def poll_upload_merge_status(job_id: int) -> MergeStatus:
 
     merge_status = response.json()
     status = merge_status.get("status")
+    status_details = merge_status.get("status_details")
     retry_in = merge_status.get("retry_in")
 
     if not (status or retry_in):
         raise ApiError(
-            "The server responded with an unexpected message.")
+            "The server responded with an unexpected upload status message.")
 
-    return MergeStatus(status, retry_in)
+    return MergeStatus(status, status_details, retry_in)

--- a/cli/api.py
+++ b/cli/api.py
@@ -110,7 +110,7 @@ def initiate_assay_upload(assay_name: str, xlsx_file: BinaryIO) -> UploadInfo:
 def _update_assay_upload_status(job_id: int, etag: str, status: str):
     """Update the status for an existing assay upload job"""
     url = _url(f'/assay_uploads/{job_id}')
-    data = {'id': job_id, 'status': status}
+    data = {'status': status}
     if_match = {'If-Match': etag}
     response = requests.patch(url, json=data, headers=_with_auth(if_match))
 

--- a/cli/api.py
+++ b/cli/api.py
@@ -120,9 +120,9 @@ def _update_assay_upload_status(job_id: int, etag: str, status: str):
 
 def assay_upload_succeeded(job_id: int, etag: str):
     """Tell the API that an assay upload job succeeded"""
-    _update_assay_upload_status(job_id, etag, 'completed')
+    _update_assay_upload_status(job_id, etag, 'upload-completed')
 
 
 def assay_upload_failed(job_id: int, etag: str):
     """Tell the API that an assay upload job failed"""
-    _update_assay_upload_status(job_id, etag, 'errored')
+    _update_assay_upload_status(job_id, etag, 'upload-failed')

--- a/cli/api.py
+++ b/cli/api.py
@@ -110,7 +110,7 @@ def initiate_assay_upload(assay_name: str, xlsx_file: BinaryIO) -> UploadInfo:
 def _update_assay_upload_status(job_id: int, etag: str, status: str):
     """Update the status for an existing assay upload job"""
     url = _url(f'/assay_uploads/{job_id}')
-    data = {'status': status}
+    data = {'id': job_id, 'status': status}
     if_match = {'If-Match': etag}
     response = requests.patch(url, json=data, headers=_with_auth(if_match))
 
@@ -128,7 +128,7 @@ def assay_upload_failed(job_id: int, etag: str):
     _update_assay_upload_status(job_id, etag, 'upload-failed')
 
 
-class MergeStatus:
+class MergeStatus(NamedTuple):
     status: Optional[str]
     retry_in: Optional[int]
 

--- a/cli/api.py
+++ b/cli/api.py
@@ -26,7 +26,7 @@ def _error_message(response: requests.Response):
         if type(message) == dict and "errors" in message:
             return 'Multiple errors:\n  ' + '\n  '.join(map(str, message["errors"]))
         else:
-            return str(message) 
+            return str(message)
     except:
         return f"API server encountered an error processing your request {response.status_code}"
 

--- a/cli/upload.py
+++ b/cli/upload.py
@@ -120,6 +120,8 @@ def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_tes
     if _did_timeout_test_impl:
         did_timeout = _did_timeout_test_impl
 
+    debug_info_message = f"Please include this info in your inquiry: (job_id={job_id})"
+
     while not did_timeout():
         status = api.poll_upload_merge_status(job_id)
         if status.retry_in:
@@ -131,7 +133,7 @@ def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_tes
                 click.echo(".", nl=False)
                 time.sleep(1)
         elif status.status:
-            if 'complete' in status.status:
+            if 'merge-completed' in status.status:
                 click.echo(click.style("✓", fg="green", bold=True))
                 click.echo(
                     "Upload succeeded. Visit the CIDC Portal "
@@ -149,6 +151,7 @@ def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_tes
                     click.echo("Upload failed. ", nl=False)
                 click.echo("Please contact a CIDC administrator "
                            "(cidc@jimmy.harvard.edu) if you need assistance.")
+                click.echo(debug_info_message)
             return
         else:
             # we should never reach this code block
@@ -158,6 +161,7 @@ def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_tes
     click.echo(
         "Upload timed out. Please contact a CIDC administrator "
         "(cidc@jimmy.harvard.edu) for assistance.")
+    click.echo(debug_info_message)
 
 
 def _handle_upload_exc(e: Exception):

--- a/cli/upload.py
+++ b/cli/upload.py
@@ -47,8 +47,7 @@ def upload_assay(assay_type: str, xlsx_path: str):
     except (Exception, KeyboardInterrupt) as e:
         # we need to notify api of a faild upload
         api.assay_upload_failed(upload_info.job_id, upload_info.job_etag)
-        # print(e.__class__)
-        raise
+        _handle_upload_exc(e)
     else:
         api.assay_upload_succeeded(upload_info.job_id, upload_info.job_etag)
         click.echo("Upload succeeded.")

--- a/cli/upload.py
+++ b/cli/upload.py
@@ -115,7 +115,7 @@ def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_tes
 
     cutoff = datetime.now().timestamp() + timeout
 
-    def did_timeout(): return datetime.now().timestamp() >= cutoff
+   did_timeout = _did_timeout_test_impl or lambda: datetime.now().timestamp() >= cutoff
 
     if _did_timeout_test_impl:
         did_timeout = _did_timeout_test_impl

--- a/cli/upload.py
+++ b/cli/upload.py
@@ -32,6 +32,7 @@ def upload_assay(assay_type: str, xlsx_path: str):
     # Log in to gcloud (required for gsutil to work)
     gcloud.login()
 
+<<<<<<< HEAD
     try:
         # Read the .xlsx file and make the API call
         # that initiates the upload job and grants object-level GCS access.
@@ -40,14 +41,23 @@ def upload_assay(assay_type: str, xlsx_path: str):
 
     except (Exception, KeyboardInterrupt) as e:
         _handle_upload_exc(e)
+=======
+    # Log in to gcloud (required for gsutil to work)
+    gcloud.login()
+>>>>>>> Move gcloud.login outside the main try-except in upload_assay
 
     try:
         # Actually upload the assay
         _gsutil_assay_upload(upload_info, xlsx_path)
+<<<<<<< HEAD
     except (Exception, KeyboardInterrupt) as e:
         # we need to notify api of a faild upload
+=======
+    except:
+>>>>>>> Move gcloud.login outside the main try-except in upload_assay
         api.assay_upload_failed(upload_info.job_id, upload_info.job_etag)
-        raise e
+        # print(e.__class__)
+        raise
     else:
         api.assay_upload_succeeded(upload_info.job_id, upload_info.job_etag)
         click.echo("Upload succeeded.")

--- a/cli/upload.py
+++ b/cli/upload.py
@@ -118,9 +118,6 @@ def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_tes
     did_timeout = _did_timeout_test_impl or (
         lambda: datetime.now().timestamp() >= cutoff)
 
-    if _did_timeout_test_impl:
-        did_timeout = _did_timeout_test_impl
-
     debug_info_message = f"Please include this info in your inquiry: (job_id={job_id})"
 
     while not did_timeout():
@@ -134,7 +131,7 @@ def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_tes
                 click.echo(".", nl=False)
                 time.sleep(1)
         elif status.status:
-            if 'merge-completed' in status.status:
+            if 'merge-completed' == status.status:
                 click.echo(click.style("✓", fg="green", bold=True))
                 click.echo(
                     "Upload succeeded. Visit the CIDC Portal "

--- a/cli/upload.py
+++ b/cli/upload.py
@@ -32,7 +32,6 @@ def upload_assay(assay_type: str, xlsx_path: str):
     # Log in to gcloud (required for gsutil to work)
     gcloud.login()
 
-<<<<<<< HEAD
     try:
         # Read the .xlsx file and make the API call
         # that initiates the upload job and grants object-level GCS access.
@@ -41,20 +40,12 @@ def upload_assay(assay_type: str, xlsx_path: str):
 
     except (Exception, KeyboardInterrupt) as e:
         _handle_upload_exc(e)
-=======
-    # Log in to gcloud (required for gsutil to work)
-    gcloud.login()
->>>>>>> Move gcloud.login outside the main try-except in upload_assay
 
     try:
         # Actually upload the assay
         _gsutil_assay_upload(upload_info, xlsx_path)
-<<<<<<< HEAD
     except (Exception, KeyboardInterrupt) as e:
         # we need to notify api of a faild upload
-=======
-    except:
->>>>>>> Move gcloud.login outside the main try-except in upload_assay
         api.assay_upload_failed(upload_info.job_id, upload_info.job_etag)
         # print(e.__class__)
         raise

--- a/cli/upload.py
+++ b/cli/upload.py
@@ -115,7 +115,8 @@ def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_tes
 
     cutoff = datetime.now().timestamp() + timeout
 
-   did_timeout = _did_timeout_test_impl or lambda: datetime.now().timestamp() >= cutoff
+    did_timeout = _did_timeout_test_impl or (
+        lambda: datetime.now().timestamp() >= cutoff)
 
     if _did_timeout_test_impl:
         did_timeout = _did_timeout_test_impl

--- a/cli/upload.py
+++ b/cli/upload.py
@@ -1,5 +1,6 @@
 """Upload local files to CIDC's upload bucket"""
 import os
+import time
 import shutil
 import subprocess
 from datetime import datetime
@@ -25,8 +26,8 @@ def upload_assay(assay_type: str, xlsx_path: str):
        carry out the gsutil upload (like a mapping from local file paths
        to GCS URIs).
     3. Carry out the gsutil upload using the returned upload info.
-    4. If the gsutil upload fails, alert the api that the job failed. 
-       Else, if the upload succeeds, alert the api that the job was 
+    4. If the gsutil upload fails, alert the api that the job failed.
+       Else, if the upload succeeds, alert the api that the job was
        successful.
     """
     # Log in to gcloud (required for gsutil to work)
@@ -48,9 +49,13 @@ def upload_assay(assay_type: str, xlsx_path: str):
         # we need to notify api of a faild upload
         api.assay_upload_failed(upload_info.job_id, upload_info.job_etag)
         _handle_upload_exc(e)
+        # _handle_upload_exc should raise, but raise for good measure
+        # to guarantee execution stops here
+        raise
     else:
         api.assay_upload_succeeded(upload_info.job_id, upload_info.job_etag)
-        click.echo("Upload succeeded.")
+
+    _poll_for_upload_completion()
 
 
 def _gsutil_assay_upload(upload_info: api.UploadInfo, xlsx: str):
@@ -102,6 +107,35 @@ def _cleanup_workspace(workspace_dir: str):
     """Delete the upload workspace directory if it exists."""
     if os.path.exists(workspace_dir):
         shutil.rmtree(workspace_dir)
+
+
+def _poll_for_upload_completion(timeout: int = 120000):
+    """Repeatedly check if upload finalization either failed or succeed"""
+    click.echo("Finalizing upload")
+
+    cutoff = datetime.now().timestamp() + timeout
+    while datetime.now().timestamp() < cutoff:
+        status = api.poll_upload_merge_status()
+        if status.retry_in:
+            for _ in range(status.retry_in):
+                click.echo(".", nl=False)
+                time.sleep(1)
+        elif status.status:
+            if 'complete' in status.status:
+                click.echo(click.style("✓", fg="green", bold=True))
+                click.echo(
+                    "Upload succeeeded. Visit the CIDC Portal "
+                    "file browser to view your upload.")
+            else:
+                click.echo(click.style("✗", fg="red", bold=True))
+                click.echo(
+                    "Upload failed. Please contact a CIDC administrator "
+                    "(cidc@jimmy.harvard.edu) for assistance.")
+        else:
+            # we should never reach this code block
+            raise
+
+    click.echo(click.style('!!!', fg="yellow", bold=True))
 
 
 def _handle_upload_exc(e: Exception):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -164,8 +164,8 @@ def test_update_job_status(monkeypatch):
             return make_json_response()
         return request
 
-    monkeypatch.setattr('requests.patch', test_status('completed'))
+    monkeypatch.setattr('requests.patch', test_status('upload-completed'))
     api.assay_upload_succeeded(JOB_ID, JOB_ETAG)
 
-    monkeypatch.setattr('requests.patch', test_status('errored'))
+    monkeypatch.setattr('requests.patch', test_status('upload-failed'))
     api.assay_upload_failed(JOB_ID, JOB_ETAG)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,6 +173,8 @@ def test_update_job_status(monkeypatch):
 
 def test_poll_upload_merge_status(monkeypatch):
     """Check that poll_upload_merge status handles various responses as expected"""
+    monkeypatch.setattr(api, '_with_auth', lambda: {})
+
     def not_found_get(*args, **kwargs):
         return make_error_response("", code=404)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -159,7 +159,7 @@ def test_update_job_status(monkeypatch):
     def test_status(status):
         def request(url, json, headers):
             assert url.endswith(str(JOB_ID))
-            assert json == {'id': JOB_ID, 'status': status}
+            assert json == {'status': status}
             assert headers.get('If-Match') == JOB_ETAG
             return make_json_response()
         return request

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,6 +37,11 @@ def test_error_message_extractor():
     response = make_error_response(MSG)
     assert api._error_message(response) == MSG
 
+    # Error response without message
+    response = MagicMock()
+    response.json.side_effect = Exception()
+    response.status_code = 503
+    assert 'API server encountered an error' in api._error_message(response)
 
     MSG = ["first", "another"]
     response = make_error_response(MSG)
@@ -48,7 +53,7 @@ def test_error_message_extractor():
     response.json.side_effect = Exception()
     response.status_code = 503
     assert 'API server encountered an error' in api._error_message(response)
-    
+
     # Error response without proper json _error and 4xx code
     response = MagicMock()
     response.json.side_effect = Exception()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -188,7 +188,7 @@ def test_poll_for_upload_completion(monkeypatch):
 
     # Simulate a success
     completed = MagicMock()
-    completed.return_value = api.MergeStatus('upload-completed', None, None)
+    completed.return_value = api.MergeStatus('merge-completed', None, None)
     monkeypatch.setattr(api, "poll_upload_merge_status", completed)
     upload._poll_for_upload_completion(
         job_id, _did_timeout_test_impl=get_did_timeout(1))

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -37,6 +37,10 @@ class UploadMocks:
         monkeypatch.setattr(api, "assay_upload_failed",
                             self.assay_upload_failed)
 
+        self._poll_for_upload_completion = MagicMock()
+        monkeypatch.setattr(upload, "_poll_for_upload_completion",
+                            self._poll_for_upload_completion)
+
         monkeypatch.setattr(upload, 'UPLOAD_WORKSPACE', UPLOAD_WORKSPACE)
 
     def assert_expected_calls(self, failure=False):
@@ -47,6 +51,7 @@ class UploadMocks:
         else:
             self.assay_upload_succeeded.assert_called_once_with(
                 JOB_ID, JOB_ETAG)
+            self._poll_for_upload_completion.assert_called_once_with(JOB_ID)
 
 
 def run_isolated_upload(runner: CliRunner):
@@ -113,6 +118,7 @@ def test_upload_assay_exception(runner: CliRunner, monkeypatch):
         run_isolated_upload(runner)
 
     mocks.assert_expected_calls(failure=True)
+
 
 def test_upload_assay_api_initiate_exception(runner: CliRunner, monkeypatch):
     """


### PR DESCRIPTION
Uses the `ingestion/poll_upload_merge_status` (https://github.com/CIMAC-CIDC/cidc-api-gae/pull/95) endpoint to repeatedly check for `ingest_upload` cloud function success or failure, or otherwise time out. Adds:
* `api.poll_upload_merge_status`: client for the `ingestion/poll_upload_merge_status` endpoint
* `upload._poll_for_upload_completion`: upload status polling logic

A half-decent way to test this by hand locally involves spinning up a local instance of the API (with code from https://github.com/CIMAC-CIDC/cidc-api-gae/pull/95), running an upload with the CLI in `dev` mode, and then manually updating the status of the generated `assay_uploads` record in `psql`. 