### PR TITLE
Increase upload timeout

### DIFF
--- a/cli/upload.py
+++ b/cli/upload.py
@@ -109,7 +109,7 @@ def _cleanup_workspace(workspace_dir: str):
         shutil.rmtree(workspace_dir)
 
 
-def _poll_for_upload_completion(job_id: int, timeout: int = 60, _did_timeout_test_impl=None):
+def _poll_for_upload_completion(job_id: int, timeout: int = 120, _did_timeout_test_impl=None):
     """Repeatedly check if upload finalization either failed or succeed"""
     click.echo("Finalizing upload", nl=False)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="cidc_cli",
-    version="0.5.0",
+    version="0.5.1",
     packages=find_packages(exclude=("tests")),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
When the `ingest_upload` cloud function has been asleep or was just updated, this limit might be reached even if the ingestion ultimately succeeds.