### PR TITLE
Fix empty files on request retries

### DIFF
--- a/cli/api.py
+++ b/cli/api.py
@@ -122,6 +122,11 @@ def retry_with_reauth(api_request):
             if not retry:
                 break
 
+            # # Rewind any file pointers to avoid sending empty files on retry
+            # if 'files' in kwargs:
+            #     for file in kwargs['files'].values():
+            #         file.seek(0)
+
         # Handle error responses
         if res.status_code != 200:
             raise ApiError(_error_message(res))

--- a/cli/api.py
+++ b/cli/api.py
@@ -122,10 +122,10 @@ def retry_with_reauth(api_request):
             if not retry:
                 break
 
-            # # Rewind any file pointers to avoid sending empty files on retry
-            # if 'files' in kwargs:
-            #     for file in kwargs['files'].values():
-            #         file.seek(0)
+            # Rewind any file pointers to avoid sending empty files on retry
+            if "files" in kwargs:
+                for file in kwargs["files"].values():
+                    file.seek(0)
 
         # Handle error responses
         if res.status_code != 200:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-from cli.api import retry_with_reauth
 import sys
 from io import BytesIO, StringIO
 


### PR DESCRIPTION
When the `requests` library prepares a request with files in the body, it reads those files from provided file pointers without rewinding the file pointers. As a result, when `retry_with_reauth` triggers request retries on requests that involve file pointers, the files sent in the retry request body will be empty, since the file pointers were already consumed when preparing the first, failed request.

Now, `retry_with_reauth` will check whether the request involves file pointers, and it will rewind all of them if there are any.