### PR TITLE
CIDC-1218 drop python 3.6, add 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## What

Drop python v3.6, add v3.9 to CI testing matrix

## Why

Describe what motivated this Pull Request and why this was necessary. Link to the relevant JIRA Issue. Ex. Closes CIDC-1086

## How

Describe details of how you implemented the solution, outlining the major steps involved in adding this new feature or fixing this bug. Provide code-snippets if possible, showing example usage.

## Remarks

Add notes on possible known quirks/drawbacks of this solution.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the Schemas package version in [`cli/__init__.py`](https://github.com/CIMAC-CIDC/cidc-cli/blob/master/cli/__init__.py#L1)
