### PR TITLE
CIDC-1388 add pypi long_description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This Changelog tracks changes to this project. The notes below include a summary
 ## Version `0.9.17` - 12 Jul 2022
 
 - `changed` local optional file handling for uploads with prepended folder
+- `added` README as long_description for PyPI
 
 ## Version `0.9.16` - 28 Apr 2022
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from setuptools import setup, find_packages
 
 from cli import __version__
 
+with open("README.md") as readme_file:
+    readme = readme_file.read()
+
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
@@ -16,7 +19,8 @@ setup(
     packages=find_packages(exclude=("tests")),
     entry_points={"console_scripts": ["cidc = cli.cli:cidc"]},
     description="A command-line interface for interacting with the CIDC.",
-    # TODO: Add a long_description, since external people may use this.
+    long_description=readme,
+    long_description_content_type="text/markdown",
     install_requires=requirements,
     python_requires=">=3.6",
 )


### PR DESCRIPTION
## Why

Previous pypi deploy failed on non-existent `long_description`

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cli/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cli/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the CLI package version in [`cli/__init__.py`](https://github.com/CIMAC-CIDC/cidc-cli/blob/master/cli/__init__.py#L1)
